### PR TITLE
switch tf minimal version from 1.3.6 to 1.5.0

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ RUN sudo apt update && sudo apt -y install \
     jq \
     python3-aodhclient \
     python3-barbicanclient \
-    python3-ceilometerclient \
+    python3-ceilometer \
     python3-cinderclient \
     python3-cloudkittyclient \
     python3-designateclient \

--- a/examples/01/providers.tf
+++ b/examples/01/providers.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/examples/02/providers.tf
+++ b/examples/02/providers.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/examples/03/providers.tf
+++ b/examples/03/providers.tf
@@ -8,7 +8,7 @@ terraform {
       source  = "hashicorp/helm"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }
 
 provider "helm" {

--- a/modules/database/mongodb_pvnw/providers.tf
+++ b/modules/database/mongodb_pvnw/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/database/mysql_pvnw/providers.tf
+++ b/modules/database/mysql_pvnw/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/floating_ip/providers.tf
+++ b/modules/floating_ip/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/instance_simple/providers.tf
+++ b/modules/instance_simple/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/kubernetes/k8s_pvnw/providers.tf
+++ b/modules/kubernetes/k8s_pvnw/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/private_network/providers.tf
+++ b/modules/private_network/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 1.49.0"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }

--- a/modules/ssh_keypair/providers.tf
+++ b/modules/ssh_keypair/providers.tf
@@ -8,5 +8,5 @@ terraform {
       version = "~> 2.2.3"
     }
   }
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.5.0"
 }


### PR DESCRIPTION
Replace the minimal Terraform version in all providers.tf files
Cause : the 1.3.6 version is now too far from the actuel one (1.5.3) so it gives an error when initializing