### PR TITLE
Update wordpress use case for summit demo

### DIFF
--- a/use-cases/wordpress-k8s-mysql/01-kube/network.tf
+++ b/use-cases/wordpress-k8s-mysql/01-kube/network.tf
@@ -20,32 +20,3 @@ resource "ovh_cloud_project_gateway" "gateway" {
   network_id = tolist(ovh_cloud_project_network_private.private_network.regions_attributes[*].openstackid)[0]
   subnet_id  = ovh_cloud_project_network_private_subnet.subnet.id
 }
-
-
-/*data "openstack_networking_network_v2" "ext_net" {
-  name     = "Ext-Net"
-  external = true
-}
-resource "openstack_networking_network_v2" "network" {
-  name = "private_network"
-}
-
-
-resource "openstack_networking_subnet_v2" "subnet" {
-  name            = "subnet"
-  network_id      = openstack_networking_network_v2.network.id
-  cidr            = "10.0.0.0/24"
-  gateway_ip      = "10.0.0.254"
-  dns_nameservers = ["213.186.33.99"]
-  ip_version      = 4
-}
-
-resource "openstack_networking_router_v2" "router" {
-  name                = "router"
-  external_network_id = data.openstack_networking_network_v2.ext_net.id
-}
-
-resource "openstack_networking_router_interface_v2" "router_itf_priv" {
-  router_id = openstack_networking_router_v2.router.id
-  subnet_id = openstack_networking_subnet_v2.subnet.id
-}*/

--- a/use-cases/wordpress-k8s-mysql/01-kube/provider.tf
+++ b/use-cases/wordpress-k8s-mysql/01-kube/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ovh = {
       source  = "ovh/ovh"
-      version = "~> 0.43.1"
+      version = "~> 1.0.0"
     }
   }
 }

--- a/use-cases/wordpress-k8s-mysql/01-kube/provider.tf
+++ b/use-cases/wordpress-k8s-mysql/01-kube/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ovh = {
       source  = "ovh/ovh"
-      version = "~> 1.0.0"
+      version = "~> 1.1.0"
     }
   }
 }

--- a/use-cases/wordpress-k8s-mysql/01-kube/variables.tf
+++ b/use-cases/wordpress-k8s-mysql/01-kube/variables.tf
@@ -8,10 +8,10 @@ variable "kubernetes" {
 
 variable "resource_prefix" {
   type    = string
-  default = "tf-public-cloud-examples-workpress-on-mks-with-mysql-"
+  default = "tf-public-cloud-examples-wordpress-on-mks-with-mysql-"
 }
 
 variable "node_pool_flavor_name" {
   type    = string
-  default = "b2-7"
+  default = "b3-8"
 }

--- a/use-cases/wordpress-k8s-mysql/02-db-wordpress/provider.tf
+++ b/use-cases/wordpress-k8s-mysql/02-db-wordpress/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ovh = {
       source  = "ovh/ovh"
-      version = "~> 1.0.0"
+      version = "~> 1.1.0"
 
     }
     helm = {

--- a/use-cases/wordpress-k8s-mysql/02-db-wordpress/provider.tf
+++ b/use-cases/wordpress-k8s-mysql/02-db-wordpress/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ovh = {
       source  = "ovh/ovh"
-      version = "~> 0.43.1"
+      version = "~> 1.0.0"
 
     }
     helm = {

--- a/use-cases/wordpress-k8s-mysql/README.md
+++ b/use-cases/wordpress-k8s-mysql/README.md
@@ -1,4 +1,4 @@
-# Deploy a Wordpress website and MySQL DB with Terraform
+# Deploy a Wordpress website and MySQL DB with Terraform / OpenTofu
 
 The purpose of this tutorial is to create a Mysql database and a Wordpress website and link them together in a Kubernetes cluster.
 
@@ -11,11 +11,12 @@ We will divide the project into two layers. The first layer is used to deploy th
 ## Requirements
 
 You need the following:
-* [Terraform](https://www.terraform.io/) installed
+* [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/) installed
 * an [OVHcloud Public cloud project](https://www.ovhcloud.com/en/public-cloud/)
 * OVHcloud API credentials
     * [EU](https://www.ovh.com/auth/?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fauth%2FcreateToken%2F%3F)
     * [CA](https://ca.ovh.com/auth/?onsuccess=https%3A//ca.ovh.com%2Fauth%2FcreateToken%2F%3F)
+
 ## Set the environment variables
 
 ```bash
@@ -60,7 +61,7 @@ export OVH_CLOUD_PROJECT_SERVICE="xxx"
 
 ## Build and run
 
-### Create the Terraform variables file (configuration)
+### Create the Terraform / OpenTofu variables file (configuration)
 
 Two Terraform variables configuration files have been already created. Edit them to modify the needed information.
 
@@ -94,28 +95,28 @@ Customize the values if needed.
 
 ```bash
 cd 01-kube
-terraform init
-terraform plan -var-file=../variables_01.tfvars
+tofu init
+tofu plan -var-file=../variables_01.tfvars
 ```
 
 ### Create the cluster and the nodes-pool - 01-kube
 
 ```bash
-terraform apply -var-file=../variables_01.tfvars -auto-approve
+tofu apply -var-file=../variables_01.tfvars -auto-approve
 ```
 
 ### Validate the configuration - 02-db-wordpress
 
 ```bash
 cd ../02-db-wordpress
-terraform init
-terraform plan -var-file=../variables_02.tfvars
+tofu init
+tofu plan -var-file=../variables_02.tfvars
 ```
 
 ### Create the DB, website - 02-db-wordpress
 
 ```bash
-terraform apply -var-file=../variables_02.tfvars -auto-approve
+tofu apply -var-file=../variables_02.tfvars -auto-approve
 ```
 
 ### Login into Wordpress 
@@ -136,7 +137,7 @@ kubectl --kubeconfig=./kubeconfig.yml get secret -n default wordpress -o jsonpat
 
 ```bash
 cd 02-db-wordpress
-terraform destroy -var-file=../variables_02.tfvars -auto-approve
+tofu destroy -var-file=../variables_02.tfvars -auto-approve
 cd ../01-kube
-terraform destroy -var-file=../variables_01.tfvars -auto-approve
+tofu destroy -var-file=../variables_01.tfvars -auto-approve
 ```

--- a/use-cases/wordpress-k8s-mysql/README.md
+++ b/use-cases/wordpress-k8s-mysql/README.md
@@ -11,7 +11,7 @@ We will divide the project into two layers. The first layer is used to deploy th
 ## Requirements
 
 You need the following:
-* [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/) installed. In the instructions below, we are using the former. If you use the latter, you will need to update the commands accordingly !
+* [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/) installed. In the instructions below, we use the first option. If you use the second, you will need to update the commands accordingly.
 * an [OVHcloud Public cloud project](https://www.ovhcloud.com/en/public-cloud/)
 * OVHcloud API credentials
     * [EU](https://www.ovh.com/auth/?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fauth%2FcreateToken%2F%3F)

--- a/use-cases/wordpress-k8s-mysql/README.md
+++ b/use-cases/wordpress-k8s-mysql/README.md
@@ -11,7 +11,7 @@ We will divide the project into two layers. The first layer is used to deploy th
 ## Requirements
 
 You need the following:
-* [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/) installed
+* [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/) installed. In the instructions below, we are using the former. If you use the latter, you will need to update the commands accordingly !
 * an [OVHcloud Public cloud project](https://www.ovhcloud.com/en/public-cloud/)
 * OVHcloud API credentials
     * [EU](https://www.ovh.com/auth/?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fauth%2FcreateToken%2F%3F)
@@ -95,28 +95,28 @@ Customize the values if needed.
 
 ```bash
 cd 01-kube
-tofu init
-tofu plan -var-file=../variables_01.tfvars
+terraform init
+terraform plan -var-file=../variables_01.tfvars
 ```
 
 ### Create the cluster and the nodes-pool - 01-kube
 
 ```bash
-tofu apply -var-file=../variables_01.tfvars -auto-approve
+terraform apply -var-file=../variables_01.tfvars -auto-approve
 ```
 
 ### Validate the configuration - 02-db-wordpress
 
 ```bash
 cd ../02-db-wordpress
-tofu init
-tofu plan -var-file=../variables_02.tfvars
+terraform init
+terraform plan -var-file=../variables_02.tfvars
 ```
 
 ### Create the DB, website - 02-db-wordpress
 
 ```bash
-tofu apply -var-file=../variables_02.tfvars -auto-approve
+terraform apply -var-file=../variables_02.tfvars -auto-approve
 ```
 
 ### Login into Wordpress 
@@ -137,7 +137,7 @@ kubectl --kubeconfig=./kubeconfig.yml get secret -n default wordpress -o jsonpat
 
 ```bash
 cd 02-db-wordpress
-tofu destroy -var-file=../variables_02.tfvars -auto-approve
+terraform destroy -var-file=../variables_02.tfvars -auto-approve
 cd ../01-kube
-tofu destroy -var-file=../variables_01.tfvars -auto-approve
+terraform destroy -var-file=../variables_01.tfvars -auto-approve
 ```


### PR DESCRIPTION
## Kind of the Pull Request

 - [ ] ✨ New demos ✨
 - [ ] 🐛 Bug 🐛
 - [x ] 🌟 Enhancement 🌟
 - [ ] 📝 Documentation 📝

## Products targeted

 - [ ] 🧠 AI 🧠
 - [ ] 💿 DBaaS 💿
 - [ ] ⎈ Managed Kubernetes Service / Managed Private Registry / Managed Rancher Service ⎈
 - [x ] 🏗️ IaC 🏗️ 

## Purpose of this Pull Request
* replace terraform by  opentofu in CLI examples
* update instance default flavor to gen 3
* bump ovh provider to 1.0.0