### PR TITLE
fix empty `ingress-nginx-values.yaml`

### DIFF
--- a/containers-orchestration/managed-kubernetes/gpu-cluster-for-vllm-deployment-and-observability/ingress/ingress-nginx-values.yaml
+++ b/containers-orchestration/managed-kubernetes/gpu-cluster-for-vllm-deployment-and-observability/ingress/ingress-nginx-values.yaml
@@ -1,0 +1,27 @@
+controller:
+  replicaCount: 2
+
+  service:
+    type: LoadBalancer
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # required for streaming responses and large multimodal payloads (images)
+  config:
+    proxy-body-size: "100m"
+    proxy-read-timeout: "300"
+    proxy-send-timeout: "300"
+
+  # exposes the /metrics endpoint
+  metrics:
+    enabled: true
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1


### PR DESCRIPTION
<!-- Please set a comprehensive title for your pull request. -->
<!-- Please fill, if applicable, the following sections. -->

## Kind of the Pull Request

 - [ ] ✨ New demos ✨
 - [x] 🐛 Bug 🐛
 - [ ] 🌟 Enhancement 🌟
 - [ ] 📝 Documentation 📝

## Products targeted

 - [ ] 🧠 AI (Deploy, Notebook, Training, Endpoints...) 🧠
 - [ ] 💿 Databases & Analytics (DBs, Data Platform, LDP...) 💿
 - [ ] 📁 Storage (Object Storage, Block Storage...) 📁
 - [x] ⎈ Containers & Orchestration (Kubernetes, Registry, Rancher...) ⎈
 - [ ] 🔒 IAM/KMS 🔒
 - [ ] 🛜 Network 🛜
 - [ ] 🏗️ IaC 🏗️ 

## Purpose of this Pull Request

<!-- Describe here what is the purpose of your pull request. -->
fix the empty `ingress/ingress-nginx-values.yaml` in **gpu-cluster-for-vllm-deployment-and-observability** tutorial

 - [x] detailed README provided
